### PR TITLE
Fix fail to load image

### DIFF
--- a/procgen/src/resources.cpp
+++ b/procgen/src/resources.cpp
@@ -357,7 +357,6 @@ void images_load() {
         "kenney/Items/flagRed_down.png",
         "kenney/Items/flagGreen1.png",
         "kenney/Items/gemRed.png",
-        "kenney/Items/yellow.png",
         "kenney/Items/yellow_line.png",
         "kenney/Items/yellow_line_diag.png",
         "kenney/Items/red_line_diag.png",

--- a/procgen/src/resources.cpp
+++ b/procgen/src/resources.cpp
@@ -357,7 +357,6 @@ void images_load() {
         "kenney/Items/flagRed_down.png",
         "kenney/Items/flagGreen1.png",
         "kenney/Items/gemRed.png",
-        "kenney/Items/yellow_line.png",
         "kenney/Items/yellow_line_diag.png",
         "kenney/Items/red_line_diag.png",
         "kenney/Enemies/snail_shell.png",


### PR DESCRIPTION
Hi,
when I try to run the code it fails with this error:
```
fatal: fatal: fatal: failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
fatal: fatal: failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
fatal: failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
fatal: failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
fatal: failed to load image /venv/lib/python3.8/site-packages/procgen/data/assets/kenney/Items/yellow.png
```

If I remove these lines, which seem to point to assets that don't exist, it works.
Is this a problem on my end, since I assume you would have come across this error already?

Anyway, might as well PR this, in case it helps.