### PR TITLE
Fix installing from pip by adding setup requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,12 @@ setup(
     name="procgen",
     packages=find_packages(),
     version=version,
+    setup_requires=[
+        "gym3>=0.3.3,<1.0.0",
+    ],
     install_requires=[
         "numpy>=1.17.0,<2.0.0",
         "gym>=0.15.0,<1.0.0",
-        "gym3>=0.3.3,<1.0.0",
         "filelock>=3.0.0,<4.0.0",
     ],
     python_requires=">=3.6.0",


### PR DESCRIPTION
As can be seen [here](https://github.com/JacobPfau/procgenAISC/blob/822dd9764593002086b38abcfb4d98e6789dc550/procgen/build.py#L11), procgen requires gym3 during build.
Now you might think that's no problem since gym3 is in the dependencies, but these dependencies are actually installed _after_ the build.
When moving the gym3 requirement into the `setup_requires` dependencies, this change allows people to directly install procgen using e.g. pip like so: `pip install "procgen @ git+https://github.com/JacobPfau/procgenAISC.git"`, without needing to manually install gym3 before or something like that.